### PR TITLE
Add FastAPI app with SQLAlchemy models

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+from fastapi import Depends, FastAPI
+from sqlalchemy.orm import Session
+
+import models
+from database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/users/")
+def create_user(name: str, db: Session = Depends(get_db)):
+    user = models.User(name=name)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@app.get("/users/")
+def read_users(db: Session = Depends(get_db)):
+    return db.query(models.User).all()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+
+from database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)


### PR DESCRIPTION
## Summary
- set up SQLAlchemy SQLite database and session
- define a basic User model
- create FastAPI app with user create and list endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f220094d483288a686c38693b6ef9