### PR TITLE
Add opportunities endpoint with Pydantic schemas

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 from fastapi import Depends, FastAPI
 from sqlalchemy.orm import Session
+from pydantic import BaseModel
+from typing import List
 
 import models
 from database import SessionLocal, engine
@@ -17,7 +19,23 @@ def get_db():
         db.close()
 
 
-@app.post("/users/")
+class UserSchema(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
+
+class OpportunitySchema(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
+
+@app.post("/users/", response_model=UserSchema)
 def create_user(name: str, db: Session = Depends(get_db)):
     user = models.User(name=name)
     db.add(user)
@@ -26,6 +44,11 @@ def create_user(name: str, db: Session = Depends(get_db)):
     return user
 
 
-@app.get("/users/")
+@app.get("/users/", response_model=List[UserSchema])
 def read_users(db: Session = Depends(get_db)):
     return db.query(models.User).all()
+
+
+@app.get("/opportunities/", response_model=List[OpportunitySchema])
+def read_opportunities(db: Session = Depends(get_db)):
+    return db.query(models.Opportunity).all()

--- a/models.py
+++ b/models.py
@@ -8,3 +8,10 @@ class User(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, index=True, nullable=False)
+
+
+class Opportunity(Base):
+    __tablename__ = "opportunities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)


### PR DESCRIPTION
## Summary
- define SQLAlchemy model for Opportunity
- add Pydantic schemas for users and opportunities
- expose `/opportunities` endpoint to list all opportunities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f2402cdf8832886edfdf2e96ba679