### PR TITLE
feat: configure API base URL and proxy

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,9 +4,11 @@ import './App.css'
 function App() {
   const [opportunities, setOpportunities] = useState(null)
 
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+
   const fetchOpportunities = async () => {
     try {
-      const response = await fetch('/opportunities')
+      const response = await fetch(`${API_BASE_URL}/opportunities/`)
       const data = await response.json()
       setOpportunities(data)
     } catch (error) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: { '/opportunities': 'http://localhost:8000' }
+  }
 })


### PR DESCRIPTION
## Summary
- use environment variable for backend URL in React app
- proxy API requests to backend in Vite dev server
- add default API base URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f28ebb42c8328b7c4755c1b9dd507