### PR TITLE
Fix opportunities fetch path

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,7 @@ function App() {
 
   const fetchOpportunities = async () => {
     try {
-      const response = await fetch('/opportunities')
+      const response = await fetch('/opportunities/')
       const data = await response.json()
       setOpportunities(data)
     } catch (error) {


### PR DESCRIPTION
## Summary
- fetch opportunities using `/opportunities/` to match backend route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f28eeba1c83288e59ebfc73e82a3a