### PR TITLE
feat: make CORS origins configurable

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 import models
 from database import SessionLocal, engine
+from settings import ALLOWED_ORIGINS
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -13,7 +14,7 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,21 @@
+"""Application configuration settings."""
+
+from typing import List
+import os
+
+
+def _get_allowed_origins() -> List[str]:
+    """Return a list of allowed origins for CORS.
+
+    The value is read from the ``ALLOWED_ORIGINS`` environment variable, which
+    should contain a comma-separated list of origins. If the variable is not
+    set, the default development origin is used.
+    """
+
+    raw_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173")
+    return [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+
+
+# Expose the configured origins as a constant for importers.
+ALLOWED_ORIGINS = _get_allowed_origins()
+


### PR DESCRIPTION
## Summary
- allow overriding CORS origins via `ALLOWED_ORIGINS` environment variable
- default to development origin when not set

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f42c283808328864eb6bafd358242