### PR TITLE
Sanitize API base URL for opportunities fetch

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,11 +3,11 @@ import './App.css'
 
 function App() {
   const [opportunities, setOpportunities] = useState(null)
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+  const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '')
 
   const fetchOpportunities = async () => {
     try {
-      const response = await fetch(`${API_BASE_URL}/opportunities/`)
+      const response = await fetch(new URL('/opportunities/', API_BASE_URL))
       const data = await response.json()
       setOpportunities(data)
     } catch (error) {


### PR DESCRIPTION
## Summary
- strip trailing slash from API base URL and build opportunity endpoint with `new URL`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f42c429c4832896485ca5e64a1f7e