### PR TITLE
Remove psycopg2-binary dependency and parameterize DB URL

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,11 +1,16 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+connect_args = (
+    {"check_same_thread": False}
+    if SQLALCHEMY_DATABASE_URL.startswith("sqlite")
+    else {}
 )
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args=connect_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 fastapi
 sqlalchemy
-psycopg2-binary
 uvicorn
 pydantic
 python-dotenv


### PR DESCRIPTION
## Summary
- remove psycopg2-binary from Python dependencies
- allow database URL to be configured via `DATABASE_URL` env var, keeping driver support

## Testing
- `pip install -r requirements.txt`
- `pip freeze | head -n 20`
- `python -m py_compile database.py main.py models.py settings.py`


------
https://chatgpt.com/codex/tasks/task_e_688f4f2489d88328beda321e19cb811e