### PR TITLE
Fetch opportunities automatically in React frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,4 +13,5 @@ This React application provides a simple interface to the CaseCycle FastAPI back
    npm run dev
    ```
 
-The single page includes a **Fetch Opportunities** button which requests `/opportunities` from the backend and displays the JSON response.
+On load, the single page requests `/opportunities/` from the backend and displays the JSON response.
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './App.css';
 
 function App() {
@@ -8,27 +8,30 @@ function App() {
   // Use the sanitized base URL (from `main`)
   const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
 
-  const fetchOpportunities = async () => {
-    try {
-      setErrorMessage(null);
+  useEffect(() => {
+    const fetchOpportunities = async () => {
+      try {
+        setErrorMessage(null);
 
-      // Build the URL safely and check the response status
-      const response = await fetch(new URL('/opportunities/', API_BASE_URL));
-      if (!response.ok) {
-        throw new Error('Network response was not ok');
+        // Build the URL safely and check the response status
+        const response = await fetch(new URL('/opportunities/', API_BASE_URL));
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        const data = await response.json();
+        setOpportunities(data);
+      } catch (error) {
+        console.error('Error fetching opportunities:', error);
+        setErrorMessage('Unable to fetch opportunities. Please try again later.');
       }
+    };
 
-      const data = await response.json();
-      setOpportunities(data);
-    } catch (error) {
-      console.error('Error fetching opportunities:', error);
-      setErrorMessage('Unable to fetch opportunities. Please try again later.');
-    }
-  };
+    fetchOpportunities();
+  }, [API_BASE_URL]);
 
   return (
     <div className="App">
-      <button onClick={fetchOpportunities}>Fetch Opportunities</button>
       {errorMessage && <div role="alert">{errorMessage}</div>}
       {opportunities && <pre>{JSON.stringify(opportunities, null, 2)}</pre>}
     </div>


### PR DESCRIPTION
## Summary
- Automatically load opportunities from the FastAPI backend on app start
- Document frontend behavior for fetching and displaying opportunity data

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f4f9593f8832880ddc3cba8726554