### PR TITLE
feat(frontend): add button to fetch opportunities

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,5 +13,5 @@ This React application provides a simple interface to the CaseCycle FastAPI back
    npm run dev
    ```
 
-On load, the single page requests `/opportunities/` from the backend and displays the JSON response.
+The page shows a **Fetch Opportunities** button. Clicking it requests `/opportunities/` from the backend and displays the JSON response.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import './App.css';
 
 function App() {
@@ -8,30 +8,27 @@ function App() {
   // Use the sanitized base URL (from `main`)
   const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
 
-  useEffect(() => {
-    const fetchOpportunities = async () => {
-      try {
-        setErrorMessage(null);
+  const fetchOpportunities = async () => {
+    try {
+      setErrorMessage(null);
 
-        // Build the URL safely and check the response status
-        const response = await fetch(new URL('/opportunities/', API_BASE_URL));
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-
-        const data = await response.json();
-        setOpportunities(data);
-      } catch (error) {
-        console.error('Error fetching opportunities:', error);
-        setErrorMessage('Unable to fetch opportunities. Please try again later.');
+      // Build the URL safely and check the response status
+      const response = await fetch(new URL('/opportunities/', API_BASE_URL));
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
       }
-    };
 
-    fetchOpportunities();
-  }, [API_BASE_URL]);
+      const data = await response.json();
+      setOpportunities(data);
+    } catch (error) {
+      console.error('Error fetching opportunities:', error);
+      setErrorMessage('Unable to fetch opportunities. Please try again later.');
+    }
+  };
 
   return (
     <div className="App">
+      <button onClick={fetchOpportunities}>Fetch Opportunities</button>
       {errorMessage && <div role="alert">{errorMessage}</div>}
       {opportunities && <pre>{JSON.stringify(opportunities, null, 2)}</pre>}
     </div>


### PR DESCRIPTION
## Summary
- add a Fetch Opportunities button in the React frontend that calls the FastAPI `/opportunities/` endpoint and prints the JSON
- document the fetch behavior in the frontend README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f52fc89a48328be0e76caf0896253