### PR TITLE
fix: preserve path when fetching opportunities

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,9 @@ function App() {
       setErrorMessage(null);
 
       // Build the URL safely and check the response status
-      const response = await fetch(new URL('/opportunities/', API_BASE_URL));
+      // Ensure the base URL retains any path segment by appending a trailing slash
+      // before constructing the new URL
+      const response = await fetch(new URL('opportunities/', API_BASE_URL + '/'));
       if (!response.ok) {
         throw new Error('Network response was not ok');
       }


### PR DESCRIPTION
## Summary
- preserve path segments when fetching opportunities by appending trailing slash to base URL
- document fetch URL handling for opportunities API

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f54c0bbb48328b673a2d7863c44da