### PR TITLE
Use Vite proxy with relative API path

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,15 +5,12 @@ function App() {
   const [opportunities, setOpportunities] = useState(null);
   const [errorMessage, setErrorMessage] = useState(null);
 
-  // Use the sanitized base URL (from `main`)
-  const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
-
   const fetchOpportunities = async () => {
     try {
       setErrorMessage(null);
 
-      // Build the URL safely and check the response status
-      const response = await fetch(new URL('/opportunities/', API_BASE_URL));
+      // Use a relative path so Vite's proxy forwards to the backend during development
+      const response = await fetch('/opportunities/');
       if (!response.ok) {
         throw new Error('Network response was not ok');
       }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
+    // Forward API requests to the backend during development
     proxy: { '/opportunities': 'http://localhost:8000' }
   }
 })


### PR DESCRIPTION
## Summary
- fetch opportunities with a relative `/opportunities/` path so Vite's dev proxy routes API calls
- document proxy behavior in `vite.config.js`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f54cee6bc83289733d8a6e5fbb218