### PR TITLE
Add JSON opportunity submission component to frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import './App.css';
+import OpportunityInput from './OpportunityInput';
 
 function App() {
   const [opportunities, setOpportunities] = useState(null);
@@ -28,6 +29,7 @@ function App() {
 
   return (
     <div className="App">
+      <OpportunityInput />
       <button onClick={fetchOpportunities}>Fetch Opportunities</button>
       {errorMessage && <div role="alert">{errorMessage}</div>}
       {opportunities && <pre>{JSON.stringify(opportunities, null, 2)}</pre>}

--- a/frontend/src/OpportunityInput.jsx
+++ b/frontend/src/OpportunityInput.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+function OpportunityInput() {
+  const [jsonValue, setJsonValue] = useState('');
+  const [feedback, setFeedback] = useState(null);
+
+  // Use the sanitized base URL (from `App`)
+  const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
+
+  const handleSave = async () => {
+    setFeedback(null);
+
+    let parsed;
+    try {
+      parsed = JSON.parse(jsonValue);
+    } catch {
+      setFeedback('Invalid JSON format');
+      return;
+    }
+
+    const requiredFields = [
+      'title',
+      'market_description',
+      'tam_estimate',
+      'growth_rate',
+      'consumer_insight',
+      'hypothesis',
+    ];
+    const missing = requiredFields.filter((field) => !(field in parsed));
+    if (missing.length > 0) {
+      setFeedback(`Missing fields: ${missing.join(', ')}`);
+      return;
+    }
+
+    try {
+      const response = await fetch(new URL('/opportunities/', API_BASE_URL), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(parsed),
+      });
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      setFeedback('Opportunity saved');
+    } catch (error) {
+      console.error('Error saving opportunity:', error);
+      setFeedback('Failed to save opportunity');
+    }
+  };
+
+  return (
+    <div>
+      <textarea
+        value={jsonValue}
+        onChange={(e) => setJsonValue(e.target.value)}
+        placeholder='{"title":"","market_description":"","tam_estimate":"","growth_rate":"","consumer_insight":"","hypothesis":""}'
+        rows={12}
+        cols={80}
+      />
+      <div>
+        <button onClick={handleSave}>Save</button>
+      </div>
+      {feedback && <div role="alert">{feedback}</div>}
+    </div>
+  );
+}
+
+export default OpportunityInput;


### PR DESCRIPTION
## Summary
- Create `OpportunityInput` component with textarea for JSON input and validation
- Parse/validate JSON for required fields and post to `/opportunities/`
- Embed component in `App` for manual opportunity submission

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f556c51d4832897f7219c5daf59b4