### PR TITLE
Add opportunity model and creation endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from fastapi import Depends, FastAPI
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 from fastapi.middleware.cors import CORSMiddleware
 
 import models
@@ -41,9 +41,17 @@ class UserSchema(BaseModel):
         orm_mode = True
 
 
-class OpportunitySchema(BaseModel):
+class OpportunityCreate(BaseModel):
+    title: str
+    market_description: Optional[str] = None
+    tam_estimate: Optional[float] = None
+    growth_rate: Optional[float] = None
+    consumer_insight: Optional[str] = None
+    hypothesis: Optional[str] = None
+
+
+class OpportunitySchema(OpportunityCreate):
     id: int
-    name: str
 
     class Config:
         orm_mode = True
@@ -61,6 +69,15 @@ def create_user(user: UserCreate, db: Session = Depends(get_db)):
 @app.get("/users/", response_model=List[UserSchema])
 def read_users(db: Session = Depends(get_db)):
     return db.query(models.User).all()
+
+
+@app.post("/opportunities/", response_model=OpportunitySchema)
+def create_opportunity(opportunity: OpportunityCreate, db: Session = Depends(get_db)):
+    db_opportunity = models.Opportunity(**opportunity.dict())
+    db.add(db_opportunity)
+    db.commit()
+    db.refresh(db_opportunity)
+    return db_opportunity
 
 
 @app.get("/opportunities/", response_model=List[OpportunitySchema])

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, Float
 
 from database import Base
 
@@ -14,4 +14,9 @@ class Opportunity(Base):
     __tablename__ = "opportunities"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, unique=True, index=True, nullable=False)
+    title = Column(String, index=True, nullable=False)
+    market_description = Column(String, nullable=True)
+    tam_estimate = Column(Float, nullable=True)
+    growth_rate = Column(Float, nullable=True)
+    consumer_insight = Column(String, nullable=True)
+    hypothesis = Column(String, nullable=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ sqlalchemy
 uvicorn
 pydantic
 python-dotenv
+pytest
+httpx

--- a/tests/test_opportunities.py
+++ b/tests/test_opportunities.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from database import Base, engine
+from main import app
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_create_opportunity():
+    client = TestClient(app)
+    payload = {
+        "title": "New Market",
+        "market_description": "Description",
+        "tam_estimate": 1000.0,
+        "growth_rate": 5.0,
+        "consumer_insight": "Insight",
+        "hypothesis": "Hypothesis",
+    }
+    response = client.post("/opportunities/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    for key, value in payload.items():
+        assert data[key] == value
+    assert "id" in data
+
+    # verify opportunity is persisted
+    list_response = client.get("/opportunities/")
+    assert list_response.status_code == 200
+    opportunities = list_response.json()
+    assert len(opportunities) == 1
+    assert opportunities[0]["title"] == payload["title"]


### PR DESCRIPTION
## Summary
- expand Opportunity ORM model with detailed fields
- add OpportunityCreate schema and POST endpoint
- cover opportunity creation with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f583247408328bbdbfdd49453d545