### PR TITLE
Show dynamic opportunity list and refresh after save

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './App.css';
 import OpportunityInput from './OpportunityInput';
 
 function App() {
-  const [opportunities, setOpportunities] = useState(null);
+  const [opportunities, setOpportunities] = useState([]);
   const [errorMessage, setErrorMessage] = useState(null);
 
   const fetchOpportunities = async () => {
@@ -24,12 +24,26 @@ function App() {
     }
   };
 
+  useEffect(() => {
+    fetchOpportunities();
+  }, []);
+
   return (
     <div className="App">
-      <OpportunityInput />
-      <button onClick={fetchOpportunities}>Fetch Opportunities</button>
+      <OpportunityInput onSaved={fetchOpportunities} />
       {errorMessage && <div role="alert">{errorMessage}</div>}
-      {opportunities && <pre>{JSON.stringify(opportunities, null, 2)}</pre>}
+      <ul>
+        {opportunities.map((opp, idx) => (
+          <li key={opp.id || idx}>
+            <h3>{opp.title}</h3>
+            <p><strong>Market Description:</strong> {opp.market_description}</p>
+            <p><strong>TAM Estimate:</strong> {opp.tam_estimate}</p>
+            <p><strong>Growth Rate:</strong> {opp.growth_rate}</p>
+            <p><strong>Consumer Insight:</strong> {opp.consumer_insight}</p>
+            <p><strong>Hypothesis:</strong> {opp.hypothesis}</p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/src/OpportunityInput.jsx
+++ b/frontend/src/OpportunityInput.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-function OpportunityInput() {
+function OpportunityInput({ onSaved }) {
   const [jsonValue, setJsonValue] = useState('');
   const [feedback, setFeedback] = useState(null);
 
@@ -44,6 +44,10 @@ function OpportunityInput() {
         throw new Error('Network response was not ok');
       }
       setFeedback('Opportunity saved');
+      setJsonValue('');
+      if (onSaved) {
+        onSaved();
+      }
     } catch (error) {
       console.error('Error saving opportunity:', error);
       setFeedback('Failed to save opportunity');


### PR DESCRIPTION
## Summary
- Automatically fetch and display opportunities when the app loads
- Refresh opportunity list after saving a new record
- Present each opportunity's key details in a clear list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f58ee4b6c8328822ca7eb949bc2f6