### PR TITLE
Validate numeric fields for opportunities

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import Depends, FastAPI
 from sqlalchemy.orm import Session
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -44,8 +44,8 @@ class UserSchema(BaseModel):
 class OpportunityCreate(BaseModel):
     title: str
     market_description: Optional[str] = None
-    tam_estimate: Optional[float] = None
-    growth_rate: Optional[float] = None
+    tam_estimate: Optional[float] = Field(default=None, gt=0)
+    growth_rate: Optional[float] = Field(default=None, ge=0)
     consumer_insight: Optional[str] = None
     hypothesis: Optional[str] = None
 

--- a/tests/test_opportunities.py
+++ b/tests/test_opportunities.py
@@ -40,3 +40,32 @@ def test_create_opportunity():
     opportunities = list_response.json()
     assert len(opportunities) == 1
     assert opportunities[0]["title"] == payload["title"]
+
+
+@pytest.mark.parametrize("tam_estimate", [-1000.0, 0.0])
+def test_create_opportunity_invalid_tam_estimate(tam_estimate):
+    client = TestClient(app)
+    payload = {
+        "title": "Invalid TAM",
+        "market_description": "Description",
+        "tam_estimate": tam_estimate,
+        "growth_rate": 5.0,
+        "consumer_insight": "Insight",
+        "hypothesis": "Hypothesis",
+    }
+    response = client.post("/opportunities/", json=payload)
+    assert response.status_code == 422
+
+
+def test_create_opportunity_invalid_growth_rate():
+    client = TestClient(app)
+    payload = {
+        "title": "Invalid Growth",
+        "market_description": "Description",
+        "tam_estimate": 1000.0,
+        "growth_rate": -1.0,
+        "consumer_insight": "Insight",
+        "hypothesis": "Hypothesis",
+    }
+    response = client.post("/opportunities/", json=payload)
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- enforce positive and non-negative numeric values in OpportunityCreate using Pydantic Field constraints
- add tests ensuring API rejects invalid numeric inputs for TAM estimates and growth rates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f604d06008328a43003578443b8ba