### PR TITLE
Add database check to healthcheck endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
 from typing import List, Optional
@@ -86,4 +88,11 @@ def read_opportunities(db: Session = Depends(get_db)):
 
 @app.get("/healthcheck")
 def healthcheck():
+    db = SessionLocal()
+    try:
+        db.execute(text("SELECT 1"))
+    except SQLAlchemyError:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    finally:
+        db.close()
     return {"status": "ok"}

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def test_healthcheck_success():
+    client = TestClient(main.app)
+    response = client.get("/healthcheck")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_healthcheck_db_failure(monkeypatch):
+    class FailingSession:
+        def execute(self, *args, **kwargs):
+            raise SQLAlchemyError()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(main, "SessionLocal", lambda: FailingSession())
+    client = TestClient(main.app)
+    response = client.get("/healthcheck")
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database unavailable"


### PR DESCRIPTION
## Summary
- ensure `/healthcheck` verifies database connectivity via `SELECT 1`
- return HTTP 503 when database is unavailable
- add tests for healthcheck success and simulated failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6375cfc48328b29a57871ba3fca2