### PR TITLE
Add prompt generation endpoint with template loading

### DIFF
--- a/prompt_templates.json
+++ b/prompt_templates.json
@@ -1,0 +1,3 @@
+{
+  "default": "Opportunity Title: {{title}}\nMarket Description: {{market_description}}\nTAM Estimate: {{tam_estimate}}\nGrowth Rate: {{growth_rate}}\nConsumer Insight: {{consumer_insight}}\nHypothesis: {{hypothesis}}"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 python-dotenv
 pytest
 httpx
+jinja2

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from database import Base, engine
+from main import app
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_generate_prompt():
+    client = TestClient(app)
+    payload = {
+        "title": "AI Widget",
+        "market_description": "Widgets for AI",
+        "tam_estimate": 5000.0,
+        "growth_rate": 12.5,
+        "consumer_insight": "Automation is valued",
+        "hypothesis": "AI widgets save time",
+    }
+    create_resp = client.post("/opportunities/", json=payload)
+    assert create_resp.status_code == 200
+    opp_id = create_resp.json()["id"]
+
+    resp = client.get(f"/prompt/{opp_id}")
+    assert resp.status_code == 200
+    prompt = resp.json()["prompt"]
+    assert f"Opportunity Title: {payload['title']}" in prompt
+    assert f"Market Description: {payload['market_description']}" in prompt
+    assert f"TAM Estimate: {payload['tam_estimate']}" in prompt
+    assert f"Growth Rate: {payload['growth_rate']}" in prompt
+    assert f"Consumer Insight: {payload['consumer_insight']}" in prompt
+    assert f"Hypothesis: {payload['hypothesis']}" in prompt


### PR DESCRIPTION
## Summary
- support editable prompt templates stored in `prompt_templates.json`
- add `/prompt/{opportunity_id}` endpoint to fill templates with opportunity data
- add test for prompt generation and include jinja2 dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f657497a48328a60d7c3966f1b545