### PR TITLE
style: apply modern minimal styling to frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>CaseCycle</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,50 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
+.site-header {
+  padding: 1rem 2rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.content {
+  flex: 1;
   padding: 2rem;
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.opportunity-input textarea {
+  width: 100%;
+  padding: 1rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  background: #fff;
+}
+
+.opportunity-list {
+  list-style: none;
+  padding: 0;
+}
+
+.opportunity-list li {
+  background: #fff;
+  border: 1px solid #e5e5ea;
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.site-footer {
+  padding: 1rem;
   text-align: center;
+  color: var(--color-muted);
+  font-size: 0.875rem;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,37 +32,41 @@ function App() {
   }, [fetchOpportunities]);
 
   return (
-    <div className="App">
-      <OpportunityInput onSaved={fetchOpportunities} />
-      {errorMessage && <div role="alert">{errorMessage}</div>}
-      <ul>
-        {opportunities.map((opp, idx) => (
-          <li key={opp.id || idx}>
-            <h3>{opp.title}</h3>
-            <p><strong>Market Description:</strong> {opp.market_description}</p>
-            <p><strong>TAM Estimate:</strong> {opp.tam_estimate}</p>
-            <p><strong>Growth Rate:</strong> {opp.growth_rate}</p>
-            <p><strong>Consumer Insight:</strong> {opp.consumer_insight}</p>
-            <p><strong>Hypothesis:</strong> {opp.hypothesis}</p>
-          </li>
-        ))}
-      </ul>
-      <div>
-        <button
-          onClick={() => setPage((p) => Math.max(p - 1, 0))}
-          disabled={page === 0}
-        >
-          Prev
-        </button>
-        <span>Page {page + 1}</span>
-        <button
-          onClick={() => setPage((p) => p + 1)}
-          disabled={opportunities.length < 10}
-        >
-          Next
-        </button>
-      </div>
-    </div>
+    <>
+      <header className="site-header">CaseCycle</header>
+      <main className="content">
+        <OpportunityInput onSaved={fetchOpportunities} />
+        {errorMessage && <div role="alert">{errorMessage}</div>}
+        <ul className="opportunity-list">
+          {opportunities.map((opp, idx) => (
+            <li key={opp.id || idx}>
+              <h3>{opp.title}</h3>
+              <p><strong>Market Description:</strong> {opp.market_description}</p>
+              <p><strong>TAM Estimate:</strong> {opp.tam_estimate}</p>
+              <p><strong>Growth Rate:</strong> {opp.growth_rate}</p>
+              <p><strong>Consumer Insight:</strong> {opp.consumer_insight}</p>
+              <p><strong>Hypothesis:</strong> {opp.hypothesis}</p>
+            </li>
+          ))}
+        </ul>
+        <div className="pagination">
+          <button
+            onClick={() => setPage((p) => Math.max(p - 1, 0))}
+            disabled={page === 0}
+          >
+            Prev
+          </button>
+          <span>Page {page + 1}</span>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={opportunities.length < 10}
+          >
+            Next
+          </button>
+        </div>
+      </main>
+      <footer className="site-footer">Mark&Measure</footer>
+    </>
   );
 }
 

--- a/frontend/src/OpportunityInput.jsx
+++ b/frontend/src/OpportunityInput.jsx
@@ -69,13 +69,12 @@ function OpportunityInput({ onSaved }) {
   };
 
   return (
-    <div>
+    <div className="opportunity-input">
       <textarea
         value={jsonValue}
         onChange={(e) => setJsonValue(e.target.value)}
         placeholder={JSON.stringify(placeholderObj)}
         rows={12}
-        cols={80}
       />
       <div>
         <button onClick={handleSave}>Save</button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,45 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --color-bg: #f5f5f7;
+  --color-text: #1d1d1f;
+  --color-muted: #6e6e73;
+  --color-accent: #007aff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
 }
 
 body {
   margin: 0;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+#root {
   display: flex;
-  place-items: center;
-  min-width: 320px;
+  flex-direction: column;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
 button {
+  background-color: var(--color-accent);
+  color: #fff;
+  border: none;
   border-radius: 8px;
-  border: 1px solid transparent;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  transition: background-color 0.2s ease-in-out;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:hover {
+  background-color: #005ecb;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+textarea {
+  font-family: inherit;
 }


### PR DESCRIPTION
## Summary
- restyle React app with modern, minimal palette and responsive layout
- add top-left CaseCycle header and bottom Mark&Measure footer
- unify inputs, lists and pagination with clean typography and neutral tones

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fb0f0fd488328bbaaafad1680699b