### PR TITLE
Add CRUD endpoints for opportunities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ starts if the ``ENVIRONMENT`` environment variable is set to ``development``:
 ENVIRONMENT=development uvicorn main:app --reload
 ```
 
+### API endpoints
+
+The backend exposes a simple REST API for working with opportunities:
+
+- `GET /opportunities/` – list opportunities.
+- `POST /opportunities/` – create a new opportunity.
+- `GET /opportunities/{id}` – retrieve a single opportunity.
+- `PUT /opportunities/{id}` / `PATCH /opportunities/{id}` – update an existing opportunity.
+- `DELETE /opportunities/{id}` – remove an opportunity.
+
 ## Troubleshooting
 
 ### Frontend shows "Unable to fetch opportunities"

--- a/tests/test_opportunities.py
+++ b/tests/test_opportunities.py
@@ -42,6 +42,49 @@ def test_create_opportunity():
     assert opportunities[0]["title"] == payload["title"]
 
 
+def test_update_opportunity():
+    client = TestClient(app)
+    payload = {
+        "title": "Original Title",
+        "market_description": "Description",
+        "tam_estimate": 1000.0,
+        "growth_rate": 5.0,
+        "consumer_insight": "Insight",
+        "hypothesis": "Hypothesis",
+    }
+    create_response = client.post("/opportunities/", json=payload)
+    opportunity_id = create_response.json()["id"]
+
+    update_payload = {"title": "Updated Title", "tam_estimate": 2000.0}
+    response = client.patch(f"/opportunities/{opportunity_id}", json=update_payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Updated Title"
+    assert data["tam_estimate"] == 2000.0
+
+    get_response = client.get(f"/opportunities/{opportunity_id}")
+    assert get_response.status_code == 200
+    fetched = get_response.json()
+    assert fetched["title"] == "Updated Title"
+
+
+def test_delete_opportunity():
+    client = TestClient(app)
+    payload = {"title": "To Delete"}
+    create_response = client.post("/opportunities/", json=payload)
+    opportunity_id = create_response.json()["id"]
+
+    response = client.delete(f"/opportunities/{opportunity_id}")
+    assert response.status_code == 204
+
+    get_response = client.get(f"/opportunities/{opportunity_id}")
+    assert get_response.status_code == 404
+
+    list_response = client.get("/opportunities/")
+    assert list_response.status_code == 200
+    assert list_response.json() == []
+
+
 @pytest.mark.parametrize("tam_estimate", [-1000.0, 0.0])
 def test_create_opportunity_invalid_tam_estimate(tam_estimate):
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- add retrieval, update, and delete endpoints for opportunities
- support partial updates via new `OpportunityUpdate` schema
- document new API endpoints
- test updating and deleting opportunities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbc5cb5b88328af833a14f708f395