### PR TITLE
Add Docker deployment and CI pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+*.pyc
+.git
+frontend/node_modules
+frontend/dist

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+exclude = frontend,node_modules
+max-line-length = 120
+extend-ignore = W293,E402

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: flake8
+      - run: pytest
+      - run: docker build -t casecycle-backend .
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm run lint
+      - run: docker build -t casecycle-frontend ./frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ starts if the ``ENVIRONMENT`` environment variable is set to ``development``:
 ENVIRONMENT=development uvicorn main:app --reload
 ```
 
+## Deployment
+
+Docker images are provided for both services. Build and start everything with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```
+
+The backend will be available at `http://localhost:8000` and the frontend at `http://localhost:3000`.
+
+To build individual images without starting containers:
+
+```bash
+# Backend
+docker build -t casecycle-backend .
+
+# Frontend
+docker build -t casecycle-frontend ./frontend
+```
+
 ## Troubleshooting
 
 ### Frontend shows "Unable to fetch opportunities"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+services:
+  backend:
+    build:
+      context: .
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ if os.getenv("ENVIRONMENT") == "development":
     def _load_sample_data() -> None:
         populate()
 
+
 @app.get("/")
 def root() -> dict:
     """Basic root endpoint to confirm the API is running."""
@@ -74,12 +75,13 @@ class OpportunityCreate(BaseModel):
     growth_rate: Optional[float] = Field(default=None, ge=0)
     consumer_insight: Optional[str] = None
     hypothesis: Optional[str] = None
-
+    
 
 class OpportunitySchema(OpportunityCreate):
     id: int
 
     model_config = ConfigDict(from_attributes=True)
+
 
 @app.post("/users/", response_model=UserSchema)
 def create_user(user: UserCreate, db: Session = Depends(get_db)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 pytest
 httpx
 jinja2
+flake8

--- a/settings.py
+++ b/settings.py
@@ -18,4 +18,3 @@ def _get_allowed_origins() -> List[str]:
 
 # Expose the configured origins as a constant for importers.
 ALLOWED_ORIGINS = _get_allowed_origins()
-


### PR DESCRIPTION
## Summary
- add Dockerfiles and docker-compose to run FastAPI and React
- run linting, tests, and image builds in GitHub Actions
- document container deployment steps

## Testing
- `flake8`
- `npm run lint`
- `pytest`
- `docker build -t test-backend .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688fbc9cd270832885127f88513a77d2