### PR TITLE
feat: use route templates for metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 pytest
 httpx
 jinja2
+prometheus-client

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+from fastapi.testclient import TestClient
+
+client = TestClient(main.app)
+
+
+def _get_request_count(path: str, method: str = "GET", status: str = "404") -> float:
+    value = main.PROMETHEUS_REGISTRY.get_sample_value(
+        "requests_total", {"method": method, "path": path, "status_code": status}
+    )
+    return value or 0.0
+
+
+def _get_latency_count(path: str, method: str = "GET") -> float:
+    value = main.PROMETHEUS_REGISTRY.get_sample_value(
+        "request_latency_seconds_count", {"method": method, "path": path}
+    )
+    return value or 0.0
+
+
+def test_metrics_use_route_template():
+    template_path = "/opportunities/{opportunity_id}"
+    count_before = _get_request_count(template_path)
+    latency_before = _get_latency_count(template_path)
+
+    response = client.get("/opportunities/123")
+    assert response.status_code == 404
+
+    count_after = _get_request_count(template_path)
+    latency_after = _get_latency_count(template_path)
+
+    assert count_after == count_before + 1
+    assert latency_after == latency_before + 1
+    # Ensure metrics are not recorded with the concrete path
+    assert _get_request_count("/opportunities/123") == 0.0

--- a/tests/test_opportunities.py
+++ b/tests/test_opportunities.py
@@ -48,6 +48,8 @@ def test_create_opportunity():
 
 def test_update_opportunity():
     client = TestClient(app)
+    user_resp = client.post("/users/", json={"name": "Alice"})
+    user_id = user_resp.json()["id"]
     payload = {
         "title": "Original Title",
         "market_description": "Description",
@@ -55,6 +57,7 @@ def test_update_opportunity():
         "growth_rate": 5.0,
         "consumer_insight": "Insight",
         "hypothesis": "Hypothesis",
+        "user_id": user_id,
     }
     create_response = client.post("/opportunities/", json=payload)
     opportunity_id = create_response.json()["id"]
@@ -74,7 +77,9 @@ def test_update_opportunity():
 
 def test_delete_opportunity():
     client = TestClient(app)
-    payload = {"title": "To Delete"}
+    user_resp = client.post("/users/", json={"name": "Alice"})
+    user_id = user_resp.json()["id"]
+    payload = {"title": "To Delete", "user_id": user_id}
     create_response = client.post("/opportunities/", json=payload)
     opportunity_id = create_response.json()["id"]
 


### PR DESCRIPTION
## Summary
- capture HTTP metrics using route templates instead of concrete paths
- expose metrics endpoint and add Prometheus dependency
- cover metrics behavior with tests and fix opportunity tests to include users

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc17695f0832895bc1ad07f597335